### PR TITLE
Add Jira report comment automation

### DIFF
--- a/src/main/java/ru/iopump/qa/allure/controller/AllureReportController.java
+++ b/src/main/java/ru/iopump/qa/allure/controller/AllureReportController.java
@@ -24,6 +24,7 @@ import ru.iopump.qa.allure.model.ReportGenerateRequest;
 import ru.iopump.qa.allure.model.ReportResponse;
 import ru.iopump.qa.allure.properties.AllureProperties;
 import ru.iopump.qa.allure.service.JpaReportService;
+import ru.iopump.qa.allure.service.JiraService;
 import ru.iopump.qa.allure.service.ResultService;
 import ru.iopump.qa.util.StreamUtil;
 
@@ -77,6 +78,7 @@ public class AllureReportController {
     private final JpaReportService reportService;
     private final ResultService resultService;
     private final AllureProperties allureProperties;
+    private final JiraService jiraService;
 
     public String baseUrl() {
         return url(allureProperties);
@@ -114,6 +116,11 @@ public class AllureReportController {
                 reportGenerateRequest.isDeleteResults(),
                 reportGenerateRequest.getReportSpec().getExecutorInfo(),
                 baseUrl()
+        );
+
+        jiraService.addReportLinkComment(
+                reportService.getReportDirectory(reportEntity.getUuid()),
+                reportEntity.generateUrl(baseUrl(), allureProperties.reports().dir()) + "index.html"
         );
 
         return new ReportResponse(


### PR DESCRIPTION
## Summary
- add a Jira integration helper that extracts an issue key from generated reports and posts a comment with the report URL
- wire JiraService into AllureReportController and send a comment after report generation

## Testing
- `gradle test` *(fails: Plugin not found because internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687f5eb8cf088331a590f2f07006c11c